### PR TITLE
Works if a repo is checked out in subdirectory

### DIFF
--- a/lib/build_participant.rb
+++ b/lib/build_participant.rb
@@ -32,8 +32,16 @@ module BuildParticipant
   def run(command, opts = {})
     info "running command #{command.inspect} with opts #{opts.inspect}"
 
+    default_dir = build.workspace.realpath
+
+    native = build.send(:native)
+    env = native.getEnvironment
+    if env.has_key?('GIT_LOCAL_SUBDIRECTORY')
+      default_dir += '/' + env['GIT_LOCAL_SUBDIRECTORY']
+    end
+
     # Set the repo directory and process streams
-    opts[:chdir] ||= build.workspace.realpath
+    opts[:chdir] ||= default_dir
     opts[:out] ||= StringIO.new
     opts[:err] ||= StringIO.new
     if stdin_str = opts.delete(:stdin_str)


### PR DESCRIPTION
You have to specify an env variable GIT_LOCAL_SUBDIRECTORY in jenkins
for your job.

It also can br used in Git section to not repeat yourself